### PR TITLE
change reaction to have 1 transition

### DIFF
--- a/include/coord2b/types/fsm.h
+++ b/include/coord2b/types/fsm.h
@@ -8,13 +8,11 @@ extern "C" {
 #endif
 
 struct event_reaction {
-    unsigned int numTransitions;
-
     /* reaction will occur if event with this index is fired */
     unsigned int conditionEventIndex;
 
-    /* transitions that can occur if the above event is fired */
-    unsigned int *transitionIndices;    // [numTransitions]
+    /* transition that can occur if the above event is fired */
+    unsigned int transitionIndex;
 
     /* events to be fired as the result of the reaction */
     unsigned int numFiredEvents;

--- a/src/example/traffic_lights.c
+++ b/src/example/traffic_lights.c
@@ -42,9 +42,19 @@ enum e_transitions {
 };
 
 enum e_reactions {
-    R_GLOBAL_TIMER = 0,
-    R_SINGLE_LIGHT_TIMEOUT,
-    R_ALWAYS_TRUE,
+    R_GLOBAL_TIMER_RED = 0,
+    R_GLOBAL_TIMER_RED_YELLOW,
+    R_GLOBAL_TIMER_GREEN,
+    R_GLOBAL_TIMER_GREEN_YELLOW,
+    R_SINGLE_LIGHT_TIMEOUT_RED,
+    R_SINGLE_LIGHT_TIMEOUT_RED_YELLOW,
+    R_SINGLE_LIGHT_TIMEOUT_GREEN,
+    R_SINGLE_LIGHT_TIMEOUT_GREEN_YELLOW,
+    R_ALWAYS_TRUE_START,
+    R_ALWAYS_TRUE_RED,
+    R_ALWAYS_TRUE_RED_YELLOW,
+    R_ALWAYS_TRUE_GREEN,
+    R_ALWAYS_TRUE_GREEN_YELLOW,
     NUM_REACTIONS
 };
 
@@ -87,6 +97,9 @@ void green_yel_behavior(struct user_data * userData) {
 
 void fsm_behavior(struct fsm_nbx *fsm, struct user_data * userData) {
     switch (fsm->currentStateIndex) {
+        case S_START:
+        case S_EXIT:
+            break;
         case S_RED:
             red_behavior(userData);
             break;
@@ -141,23 +154,39 @@ int main() {
     };
 
     struct event_reaction reactions[NUM_REACTIONS] = {
-        [R_GLOBAL_TIMER] = {
-            .numTransitions = 4, .conditionEventIndex = E_GLOBAL_TIMEOUT, .numFiredEvents = 0,
-            .transitionIndices = (unsigned int[]) {T_RED_EXIT, T_RED_YELLOW_EXIT, T_GREEN_EXIT, T_GREEN_YELLOW_EXIT}
+        [R_GLOBAL_TIMER_RED] = {
+            .conditionEventIndex = E_GLOBAL_TIMEOUT, .numFiredEvents = 0, .transitionIndex = T_RED_EXIT
         },
-        [R_SINGLE_LIGHT_TIMEOUT] = {
-            .numTransitions = 4, .conditionEventIndex = E_SINGLE_LIGHT_TIMEOUT,
-            .transitionIndices = (unsigned int[]) {
-                T_RED_YELLOW, T_RED_YELLOW_GREEN, T_GREEN_YELLOW, T_GREEN_YELLOW_RED
-            },
+        [R_GLOBAL_TIMER_RED_YELLOW] = {
+            .conditionEventIndex = E_GLOBAL_TIMEOUT, .numFiredEvents = 0, .transitionIndex = T_RED_YELLOW_EXIT
+        },
+        [R_GLOBAL_TIMER_GREEN] = {
+            .conditionEventIndex = E_GLOBAL_TIMEOUT, .numFiredEvents = 0, .transitionIndex = T_GREEN_EXIT
+        },
+        [R_GLOBAL_TIMER_GREEN_YELLOW] = {
+            .conditionEventIndex = E_GLOBAL_TIMEOUT, .numFiredEvents = 0, .transitionIndex = T_GREEN_YELLOW_EXIT
+        },
+        [R_SINGLE_LIGHT_TIMEOUT_RED] = {
+            .conditionEventIndex = E_SINGLE_LIGHT_TIMEOUT, .transitionIndex = T_RED_YELLOW,
             .numFiredEvents = 1, .firedEventIndices = (unsigned int[]) { E_LIGHT_CHANGED }
         },
-        [R_ALWAYS_TRUE] = {
-            .numTransitions = 5, .conditionEventIndex = E_STEP, .numFiredEvents = 0,
-            .transitionIndices = (unsigned int[]) {
-                T_START_RED, T_RED_RED, T_RED_YELLOW_YELLOW, T_GREEN_GREEN, T_GREEN_YELLOW_YELLOW
-            }
-        }
+        [R_SINGLE_LIGHT_TIMEOUT_RED_YELLOW] = {
+            .conditionEventIndex = E_SINGLE_LIGHT_TIMEOUT, .transitionIndex = T_RED_YELLOW_GREEN,
+            .numFiredEvents = 1, .firedEventIndices = (unsigned int[]) { E_LIGHT_CHANGED }
+        },
+        [R_SINGLE_LIGHT_TIMEOUT_GREEN] = {
+            .conditionEventIndex = E_SINGLE_LIGHT_TIMEOUT, .transitionIndex = T_GREEN_YELLOW,
+            .numFiredEvents = 1, .firedEventIndices = (unsigned int[]) { E_LIGHT_CHANGED }
+        },
+        [R_SINGLE_LIGHT_TIMEOUT_GREEN_YELLOW] = {
+            .conditionEventIndex = E_SINGLE_LIGHT_TIMEOUT, .transitionIndex = T_GREEN_YELLOW_RED,
+            .numFiredEvents = 1, .firedEventIndices = (unsigned int[]) { E_LIGHT_CHANGED }
+        },
+        [R_ALWAYS_TRUE_START] = { .conditionEventIndex = E_STEP, .numFiredEvents = 0, .transitionIndex = T_START_RED },
+        [R_ALWAYS_TRUE_RED] = { .conditionEventIndex = E_STEP, .numFiredEvents = 0, .transitionIndex = T_RED_RED },
+        [R_ALWAYS_TRUE_RED_YELLOW] = { .conditionEventIndex = E_STEP, .numFiredEvents = 0, .transitionIndex = T_RED_YELLOW_YELLOW },
+        [R_ALWAYS_TRUE_GREEN] = { .conditionEventIndex = E_STEP, .numFiredEvents = 0, .transitionIndex = T_GREEN_GREEN },
+        [R_ALWAYS_TRUE_GREEN_YELLOW] = { .conditionEventIndex = E_STEP, .numFiredEvents = 0, .transitionIndex = T_GREEN_YELLOW_YELLOW }
     };
 
     struct fsm_nbx fsm = {

--- a/src/nbx/fsm.c
+++ b/src/nbx/fsm.c
@@ -18,28 +18,17 @@ void fsm_step_nbx(struct fsm_nbx* fsm) {
 
     /* Handle transition into next state */
     int transIndex;
-    _Bool transitionFound = false;
     for (int i = 0; i < fsm->numReactions; i++) {
         // skip if event reaction not triggered
         if (!consume_event(fsm->eventData, fsm->reactions[i].conditionEventIndex)) continue;
 
-        // transition
-        assert(fsm->reactions[i].numTransitions > 0);
-        assert(fsm->reactions[i].transitionIndices);
-        for (int j = 0; j < fsm->reactions[i].numTransitions; j++) {
-            transIndex = fsm->reactions[i].transitionIndices[j];
-            assert(transIndex < fsm->numTransitions);
+        // transition, skip if current state doesn't match transition's start state
+        transIndex = fsm->reactions[i].transitionIndex;
+        assert(transIndex < fsm->numTransitions);
+        if (fsm->currentStateIndex != fsm->transitions[transIndex].startStateIndex) continue;
 
-            // skip if current state doesn't match transition's start state
-            if (fsm->currentStateIndex != fsm->transitions[transIndex].startStateIndex) continue;
-
-            // transition
-            transitionFound = true;
-            fsm->currentStateIndex = fsm->transitions[transIndex].endStateIndex;
-
-            // will only process first transition
-            break;
-        }
+        // set transition state
+        fsm->currentStateIndex = fsm->transitions[transIndex].endStateIndex;
 
         // fire any requested events
         if (fsm->reactions[i].numFiredEvents > 0) {
@@ -53,6 +42,6 @@ void fsm_step_nbx(struct fsm_nbx* fsm) {
          * and reactions signifies the priority in which they're handled, and that only the first transition
          * will be taken into account.
          */
-        if (transitionFound) break;
+        break;
     }
 }


### PR DESCRIPTION
- This matches the book's definition, which says a reaction should contain only 1 transition.
- Previous implementation is more human-friendly as transitions to the same event can be specified in a reaction. This, however, implies that the order of transitions is also prioritised in addition to the order of reactions.
- Since a code generator is now developed by Vamsi, we can follow the book implementation more closely.
- Code generation will be added to https://github.com/secorolab/coord-dsl